### PR TITLE
Move PBWDeformations v0.2.0 to new namespace

### DIFF
--- a/P/PBWDeformations/Package.toml
+++ b/P/PBWDeformations/Package.toml
@@ -1,3 +1,3 @@
 name = "PBWDeformations"
 uuid = "5e7992ee-18b2-4301-9ba0-4f17696dc75a"
-repo = "https://github.com/PBWDeformations/PBWDeformations.jl.git"
+repo = "https://github.com/lgoettgens/PBWDeformations.jl"


### PR DESCRIPTION
The github repo for PBWDeformations.jl has been transferred to my namespace. I would like the registry to reflect that. 